### PR TITLE
mf - add javascript fixtures for ucsborganization table 

### DIFF
--- a/frontend/src/fixtures/ucsbOrganizationFixtures.js
+++ b/frontend/src/fixtures/ucsbOrganizationFixtures.js
@@ -1,0 +1,34 @@
+const restaurantFixtures = {
+    oneUcsbOrganization: [
+        {
+            "orgCode": "ZPR",
+            "orgTranslationShort": "ZETA PHI RHO",
+            "orgTranslation": "ZETA PHI RHO",
+            "inactive": false
+        },
+    ],
+  
+    threeUcsbOrganizations: [
+        {
+            "orgCode": "ZPR",
+            "orgTranslationShort": "ZETA PHI RHO",
+            "orgTranslation": "ZETA PHI RHO",
+            "inactive": false
+        },
+        {
+            "orgCode": "SKY",
+            "orgTranslationShort": "SKYDIVING CLUB",
+            "orgTranslation": "SKYDIVING CLUB AT UCSB",
+            "inactive": false
+        },
+        {
+            "orgCode": "OSLI",
+            "orgTranslationShort": "STUDENT LIFE",
+            "orgTranslation": "OFFICE OF STUDENT LIFE",
+            "inactive": false
+        }
+        ]
+  };
+  
+  export { restaurantFixtures };
+  

--- a/frontend/src/fixtures/ucsbOrganizationFixtures.js
+++ b/frontend/src/fixtures/ucsbOrganizationFixtures.js
@@ -1,34 +1,33 @@
 const restaurantFixtures = {
-    oneUcsbOrganization: [
-        {
-            "orgCode": "ZPR",
-            "orgTranslationShort": "ZETA PHI RHO",
-            "orgTranslation": "ZETA PHI RHO",
-            "inactive": false
-        },
-    ],
-  
-    threeUcsbOrganizations: [
-        {
-            "orgCode": "ZPR",
-            "orgTranslationShort": "ZETA PHI RHO",
-            "orgTranslation": "ZETA PHI RHO",
-            "inactive": false
-        },
-        {
-            "orgCode": "SKY",
-            "orgTranslationShort": "SKYDIVING CLUB",
-            "orgTranslation": "SKYDIVING CLUB AT UCSB",
-            "inactive": false
-        },
-        {
-            "orgCode": "OSLI",
-            "orgTranslationShort": "STUDENT LIFE",
-            "orgTranslation": "OFFICE OF STUDENT LIFE",
-            "inactive": false
-        }
-        ]
-  };
-  
-  export { restaurantFixtures };
-  
+  oneUcsbOrganization: [
+    {
+      orgCode: "ZPR",
+      orgTranslationShort: "ZETA PHI RHO",
+      orgTranslation: "ZETA PHI RHO",
+      inactive: false,
+    },
+  ],
+
+  threeUcsbOrganizations: [
+    {
+      orgCode: "ZPR",
+      orgTranslationShort: "ZETA PHI RHO",
+      orgTranslation: "ZETA PHI RHO",
+      inactive: false,
+    },
+    {
+      orgCode: "SKY",
+      orgTranslationShort: "SKYDIVING CLUB",
+      orgTranslation: "SKYDIVING CLUB AT UCSB",
+      inactive: false,
+    },
+    {
+      orgCode: "OSLI",
+      orgTranslationShort: "STUDENT LIFE",
+      orgTranslation: "OFFICE OF STUDENT LIFE",
+      inactive: false,
+    },
+  ],
+};
+
+export { restaurantFixtures };

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationsController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationsController.java
@@ -1,0 +1,138 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.entities.UCSBOrganization;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
+import edu.ucsb.cs156.example.repositories.UCSBOrganizationRepository;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+
+/**
+ * This is a REST controller for UCSBOrganizations
+ */
+
+@Tag(name = "UCSBOrganizations")
+@RequestMapping("/api/ucsborganizations")
+@RestController
+@Slf4j
+
+public class UCSBOrganizationsController extends ApiController {
+    @Autowired 
+    UCSBOrganizationRepository ucsbOrganizationRepository;
+
+    /**
+     * THis method returns a list of all ucsborganizations.
+     * @return a list of all ucsborganizations
+     */
+    @Operation(summary= "List all ucsb organizations")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/all")
+    public Iterable<UCSBOrganization> allOrganizations() {
+        Iterable<UCSBOrganization> org = ucsbOrganizationRepository.findAll();
+        return org;
+    }
+
+    /**
+     * This method creates a new organization. Accessible only to users with the role "ROLE_ADMIN".
+     * @param orgCode code of the organization
+     * @param orgTranslationShort acronym/short name of organization
+     * @param orgTranslation full name of organization
+     * @param inactive whether or not the org is inactive
+     */
+
+    @Operation(summary= "Create a new organization")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/post")
+    public UCSBOrganization postOrganization(
+        @Parameter(name="orgCode") @RequestParam String orgCode,
+        @Parameter(name="orgTranslationShort") @RequestParam String orgTranslationShort,
+        @Parameter(name="orgTranslation") @RequestParam String orgTranslation,
+        @Parameter(name="inactive") @RequestParam boolean inactive
+        )
+        {
+
+        UCSBOrganization organization = new UCSBOrganization();
+        organization.setOrgCode(orgCode);
+        organization.setOrgTranslationShort(orgTranslationShort);
+        organization.setOrgTranslation(orgTranslation);
+        organization.setInactive(inactive);
+
+        UCSBOrganization savedOrganization = ucsbOrganizationRepository.save(organization);
+
+        return savedOrganization;
+    }
+
+    /**
+     * This method returns a single organization.
+     * @param orgCode code of the organization
+     * @return a single organization
+     */
+    @Operation(summary= "Get a single organization")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("")
+    public UCSBOrganization getById(
+            @Parameter(name="orgCode") @RequestParam String orgCode) {
+        UCSBOrganization organization = ucsbOrganizationRepository.findById(orgCode)
+                .orElseThrow(() -> new EntityNotFoundException(UCSBOrganization.class, orgCode));
+
+        return organization;
+    }
+
+    /**
+     * Delete a organiztion. Accessible only to users with the role "ROLE_ADMIN".
+     * @param orgCode code of the organization
+     * @return a message indiciating the organization was deleted
+     */
+    @Operation(summary= "Delete a UCSBOrganization")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("")
+    public Object deleteCommons(
+            @Parameter(name="orgCode") @RequestParam String orgCode) {
+        UCSBOrganization org = ucsbOrganizationRepository.findById(orgCode)
+                .orElseThrow(() -> new EntityNotFoundException(UCSBOrganization.class, orgCode));
+
+        ucsbOrganizationRepository.delete(org);
+        return genericMessage("UCSBOrganization with id %s deleted".formatted(orgCode));
+    }
+
+    /**
+     * Update a single organizatino. Accessible only to users with the role "ROLE_ADMIN".
+     * @param orgCode code of the organization
+     * @param incoming the new organization contents
+     * @return the updated organiaztnoi object
+     */
+    @Operation(summary= "Update a single organization")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PutMapping("")
+    public UCSBOrganization updateOrganization(
+            @Parameter(name="orgCode") @RequestParam String orgCode,
+            @RequestBody @Valid UCSBOrganization incoming) {
+
+        UCSBOrganization org = ucsbOrganizationRepository.findById(orgCode)
+                .orElseThrow(() -> new EntityNotFoundException(UCSBOrganization.class, orgCode));
+
+
+        org.setOrgTranslation(incoming.getOrgTranslation());  
+        org.setOrgTranslationShort(incoming.getOrgTranslationShort());
+        org.setInactive(incoming.getInactive());
+
+        ucsbOrganizationRepository.save(org);
+
+        return org;
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/example/entities/UCSBOrganization.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/UCSBOrganization.java
@@ -1,0 +1,22 @@
+package edu.ucsb.cs156.example.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "ucsborganizations")
+public class UCSBOrganization{
+    @Id
+    private String orgCode;
+    private String orgTranslationShort;
+    private String orgTranslation;
+    private boolean inactive;
+
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/UCSBOrganizationRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/UCSBOrganizationRepository.java
@@ -1,0 +1,16 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.UCSBOrganization;
+
+import org.springframework.beans.propertyeditors.StringArrayPropertyEditor;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * The UCSBOrganizationRespository is a repository for UCSBOrganization entities
+ */
+
+@Repository
+public interface UCSBOrganizationRepository extends CrudRepository<UCSBOrganization, String> {
+ 
+}

--- a/src/main/resources/db/migration/changes/UCSBOrganizations.json
+++ b/src/main/resources/db/migration/changes/UCSBOrganizations.json
@@ -1,0 +1,68 @@
+{ "databaseChangeLog": [
+    {
+        "changeSet": {
+          "id": "UCSBOrganizations-1",
+          "author": "MontgomeryF",
+          "preConditions": [
+            {
+              "onFail": "MARK_RAN"
+            },
+            {
+              "not": [
+                {
+                  "tableExists": {
+                    "tableName": "UCSBORGANIZATIONS"
+                  }
+                }
+              ]
+            }
+          ],
+          "changes": [
+            {
+              "createTable": {
+                "columns": [
+                  {
+                    "column": {
+                      "constraints": {
+                        "primaryKey": true,
+                        "primaryKeyName": "ORGANIZATIONS_PK"
+                      },
+                      "name": "ORG_CODE",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "constraints": {
+                        "nullable": false
+                      },
+                      "name": "ORG_TRANSLATION_SHORT",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "constraints": {
+                        "nullable": false
+                      },
+                      "name": "ORG_TRANSLATION",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "constraints": {
+                        "nullable": false
+                      },
+                      "name": "INACTIVE",
+                      "type": "BOOLEAN"
+                    }
+                  }]
+                ,
+                "tableName": "UCSBORGANIZATIONS"
+              }
+            }]
+
+        }
+    }
+]}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationsControllerTests.java
@@ -1,0 +1,307 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.UCSBDiningCommons;
+import edu.ucsb.cs156.example.entities.UCSBOrganization;
+import edu.ucsb.cs156.example.repositories.UCSBOrganizationRepository;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@WebMvcTest(controllers = UCSBOrganizationsController.class)
+@Import(TestConfig.class)
+public class UCSBOrganizationsControllerTests extends ControllerTestCase {
+
+    @MockBean
+    UCSBOrganizationRepository ucsbOrganizationRepository;
+
+    @MockBean
+    UserRepository userRepository;
+
+    @Test
+    public void logged_out_users_cannot_get_all() throws Exception {
+            mockMvc.perform(get("/api/ucsborganizations/all"))
+                            .andExpect(status().is(403)); // logged out users can't get all
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_users_can_get_all() throws Exception {
+            mockMvc.perform(get("/api/ucsborganizations/all"))
+                            .andExpect(status().is(200)); // logged
+    }
+
+    @Test
+        public void logged_out_users_cannot_get_by_id() throws Exception {
+                mockMvc.perform(get("/api/ucsborganizations?orgCode=test"))
+                                .andExpect(status().is(403)); // logged out users can't get by id
+        }
+
+    @Test
+        public void logged_out_users_cannot_post() throws Exception {
+                mockMvc.perform(post("/api/ucsborganizations/post"))
+                                .andExpect(status().is(403));
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_regular_users_cannot_post() throws Exception {
+                mockMvc.perform(post("/api/ucsborganizations/post"))
+                                .andExpect(status().is(403)); // only admins can post
+        }
+
+        
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_user_can_get_all_ucsborganizations() throws Exception {
+
+            // arrange
+            UCSBOrganization org = UCSBOrganization.builder()
+                            .orgCode("sigma")
+                            .orgTranslationShort("s")
+                            .orgTranslation("sigmas")
+                            .inactive(false)
+                            .build();
+
+                UCSBOrganization org2 = UCSBOrganization.builder()
+                .orgCode("omega")
+                .orgTranslationShort("o")
+                .orgTranslation("omegas")
+                .inactive(true)
+                .build();
+                
+
+            ArrayList<UCSBOrganization> expectedOrganizations = new ArrayList<>();
+            expectedOrganizations.addAll(Arrays.asList(org, org2));
+
+            when(ucsbOrganizationRepository.findAll()).thenReturn(expectedOrganizations);
+
+            // act
+            MvcResult response = mockMvc.perform(get("/api/ucsborganizations/all"))
+                            .andExpect(status().isOk()).andReturn();
+
+            // assert
+
+            verify(ucsbOrganizationRepository, times(1)).findAll();
+            String expectedJson = mapper.writeValueAsString(expectedOrganizations);
+            String responseString = response.getResponse().getContentAsString();
+            assertEquals(expectedJson, responseString);
+    }
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void an_admin_user_can_post_a_new_ucsborganization() throws Exception {
+            // arrange
+
+            UCSBOrganization org2 = UCSBOrganization.builder()
+                            .orgCode("aleph")
+                            .orgTranslationShort("a")
+                            .orgTranslation("alephs")
+                            .inactive(true)
+                            .build();
+
+            when(ucsbOrganizationRepository.save(eq(org2))).thenReturn(org2);
+
+            // act
+            MvcResult response = mockMvc.perform(
+                            post("/api/ucsborganizations/post?orgCode=aleph&orgTranslationShort=a&inactive=true&orgTranslation=alephs")
+                                            .with(csrf()))
+                            .andExpect(status().isOk()).andReturn();
+
+            // assert
+            verify(ucsbOrganizationRepository, times(1)).save(org2);
+            String expectedJson = mapper.writeValueAsString(org2);
+            String responseString = response.getResponse().getContentAsString();
+            assertEquals(expectedJson, responseString);
+    }
+
+    @WithMockUser(roles = { "USER" })
+        @Test
+        public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+
+                // arrange
+
+                when(ucsbOrganizationRepository.findById(eq("test"))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/ucsborganizations?orgCode=test"))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+
+                verify(ucsbOrganizationRepository, times(1)).findById(eq("test"));
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("EntityNotFoundException", json.get("type"));
+                assertEquals("UCSBOrganization with id test not found", json.get("message"));
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
+
+                // arrange
+
+                UCSBOrganization org3 = UCSBOrganization.builder()
+                                .orgCode("aleph")
+                                .orgTranslationShort("a")
+                                .orgTranslation("alephs")
+                                .inactive(true)
+                                .build();
+
+                when(ucsbOrganizationRepository.findById(eq("aleph"))).thenReturn(Optional.of(org3));
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/ucsborganizations?orgCode=aleph"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(ucsbOrganizationRepository, times(1)).findById(eq("aleph"));
+                String expectedJson = mapper.writeValueAsString(org3);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_can_edit_an_existing_commons() throws Exception {
+                // arrange
+
+                UCSBOrganization org = UCSBOrganization.builder()
+                        .orgCode("sigma")
+                        .orgTranslationShort("s")
+                        .orgTranslation("sigmas")
+                        .inactive(false)
+                        .build();
+
+                UCSBOrganization editedOrg = UCSBOrganization.builder()
+                        .orgCode("sigma")
+                        .orgTranslationShort("si")
+                        .orgTranslation("sigmas2")
+                        .inactive(true)
+                        .build();
+
+                String requestBody = mapper.writeValueAsString(editedOrg);
+
+                when(ucsbOrganizationRepository.findById(eq("sigma"))).thenReturn(Optional.of(org));
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                put("/api/ucsborganizations?orgCode=sigma")
+                                                .contentType(MediaType.APPLICATION_JSON)
+                                                .characterEncoding("utf-8")
+                                                .content(requestBody)
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(ucsbOrganizationRepository, times(1)).findById("sigma");
+                verify(ucsbOrganizationRepository, times(1)).save(editedOrg); // should be saved with updated info
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(requestBody, responseString);
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_cannot_edit_commons_that_does_not_exist() throws Exception {
+                // arrange
+
+                UCSBOrganization editedOrg = UCSBOrganization.builder()
+                        .orgCode("sigma")
+                        .orgTranslationShort("s")
+                        .orgTranslation("sigmas")
+                        .inactive(false)
+                        .build();
+
+                String requestBody = mapper.writeValueAsString(editedOrg);
+
+                when(ucsbOrganizationRepository.findById(eq("sigma"))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                put("/api/ucsborganizations?orgCode=sigma")
+                                                .contentType(MediaType.APPLICATION_JSON)
+                                                .characterEncoding("utf-8")
+                                                .content(requestBody)
+                                                .with(csrf()))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+                verify(ucsbOrganizationRepository, times(1)).findById("sigma");
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("UCSBOrganization with id sigma not found", json.get("message"));
+
+        }
+
+                @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_can_delete_an_organization() throws Exception {
+                // arrange
+
+                UCSBOrganization org = UCSBOrganization.builder()
+                        .orgCode("sigma")
+                        .orgTranslationShort("s")
+                        .orgTranslation("sigmas")
+                        .inactive(false)
+                        .build();
+
+                when(ucsbOrganizationRepository.findById(eq("sigma"))).thenReturn(Optional.of(org));
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                delete("/api/ucsborganizations?orgCode=sigma")
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(ucsbOrganizationRepository, times(1)).findById("sigma");
+                verify(ucsbOrganizationRepository, times(1)).delete(any());
+
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("UCSBOrganization with id sigma deleted", json.get("message"));
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_tries_to_delete_non_existant_organization_and_gets_right_error_message()
+                        throws Exception {
+                // arrange
+
+                when(ucsbOrganizationRepository.findById(eq("aleph"))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                delete("/api/ucsborganizations?orgCode=aleph")
+                                                .with(csrf()))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+                verify(ucsbOrganizationRepository, times(1)).findById("aleph");
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("UCSBOrganization with id aleph not found", json.get("message"));
+        }
+}


### PR DESCRIPTION
Closes: #18 

Merge after PR #86

In this PR we add fixtures for UCSBorganization table in the frontend code.

These will be used for storybook and tests later on.