### PR TITLE
Fahim help request table

### DIFF
--- a/frontend/src/main/components/HelpRequests/HelpRequestForm.js
+++ b/frontend/src/main/components/HelpRequests/HelpRequestForm.js
@@ -8,23 +8,25 @@ function HelpRequestForm({
   buttonLabel = "Create",
 }) {
   // Stryker disable all
-  const defaultValues = initialContents ? {
-    ...initialContents,
-    requestTime: initialContents?.requestTime.replace("Z", ""),
-  } : {
-    requesterEmail: "",
-    teamId: "",
-    tableOrBreakoutRoom: "",
-    requestTime: "",
-    explanation: "",
-    solved: false,
-  }
+  const defaultValues = initialContents
+    ? {
+        ...initialContents,
+        requestTime: initialContents?.requestTime.replace("Z", ""),
+      }
+    : {
+        requesterEmail: "",
+        teamId: "",
+        tableOrBreakoutRoom: "",
+        requestTime: "",
+        explanation: "",
+        solved: false,
+      };
 
   const {
     register,
     formState: { errors },
     handleSubmit,
-  } = useForm({defaultValues});
+  } = useForm({ defaultValues });
   // Stryker restore all
 
   const navigate = useNavigate();
@@ -153,8 +155,7 @@ function HelpRequestForm({
           id="solved"
           type="boolean"
           isInvalid={Boolean(errors.solved)}
-          {...register("solved", {
-          })}
+          {...register("solved", {})}
         />
         <Form.Control.Feedback type="invalid">
           {errors.solved?.message}

--- a/frontend/src/main/components/HelpRequests/HelpRequestForm.js
+++ b/frontend/src/main/components/HelpRequests/HelpRequestForm.js
@@ -1,0 +1,178 @@
+import { Button, Form } from "react-bootstrap";
+import { useForm } from "react-hook-form";
+import { useNavigate } from "react-router-dom";
+
+function HelpRequestForm({
+  initialContents,
+  submitAction,
+  buttonLabel = "Create",
+}) {
+  // Stryker disable all
+  const defaultValues = initialContents ? {
+    ...initialContents,
+    requestTime: initialContents?.requestTime.replace("Z", ""),
+  } : {
+    requesterEmail: "",
+    teamId: "",
+    tableOrBreakoutRoom: "",
+    requestTime: "",
+    explanation: "",
+    solved: false,
+  }
+
+  const {
+    register,
+    formState: { errors },
+    handleSubmit,
+  } = useForm({defaultValues});
+  // Stryker restore all
+
+  const navigate = useNavigate();
+
+  const testIdPrefix = "HelpRequestForm";
+
+  // For explanation, see: https://stackoverflow.com/questions/3143070/javascript-regex-iso-datetime
+  // Note that even this complex regex may still need some tweaks
+
+  // Stryker disable Regex
+  const isodate_regex =
+    /(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+)|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d)|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d)/i;
+  // Stryker restore Regex
+
+  return (
+    <Form onSubmit={handleSubmit(submitAction)}>
+      {initialContents && (
+        <Form.Group className="mb-3">
+          <Form.Label htmlFor="id">Id</Form.Label>
+          <Form.Control
+            data-testid={testIdPrefix + "-id"}
+            id="id"
+            type="text"
+            {...register("id")}
+            value={initialContents.id}
+            disabled
+          />
+        </Form.Group>
+      )}
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="requesterEmail">Email</Form.Label>
+        <Form.Control
+          data-testid={testIdPrefix + "-requesterEmail"}
+          id="requesterEmail"
+          type="text"
+          isInvalid={Boolean(errors.requesterEmail)}
+          {...register("requesterEmail", {
+            required: "Email is required.",
+            maxLength: {
+              value: 255,
+              message: "Max length 255 characters",
+            },
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.requesterEmail?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="teamId">Team ID</Form.Label>
+        <Form.Control
+          data-testid={testIdPrefix + "-teamId"}
+          id="teamId"
+          type="text"
+          isInvalid={Boolean(errors.teamId)}
+          {...register("teamId", {
+            required: "Team ID is required.",
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.teamId?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="tableOrBreakoutRoom">
+          Table/Breakout Room #
+        </Form.Label>
+        <Form.Control
+          data-testid={testIdPrefix + "-tableOrBreakoutRoom"}
+          id="tableOrBreakoutRoom"
+          type="text"
+          isInvalid={Boolean(errors.tableOrBreakoutRoom)}
+          {...register("tableOrBreakoutRoom", {
+            required: "Table or Breakout Room number is required.",
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.tableOrBreakoutRoom?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="requestTime">Request Time (in UTC)</Form.Label>
+        <Form.Control
+          data-testid={testIdPrefix + "-requestTime"}
+          id="requestTime"
+          type="datetime-local"
+          isInvalid={Boolean(errors.requestTime)}
+          {...register("requestTime", {
+            required: true,
+            pattern: isodate_regex,
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.requestTime && "Request Time is required. "}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="explanation">Explanation</Form.Label>
+        <Form.Control
+          data-testid={testIdPrefix + "-explanation"}
+          id="explanation"
+          type="text"
+          isInvalid={Boolean(errors.explanation)}
+          {...register("explanation", {
+            required: "Explanation is required.",
+            maxLength: {
+              value: 255,
+              message: "Max length 255 characters",
+            },
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.explanation?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="solved">Is it Solved? </Form.Label>
+        <Form.Control
+          data-testid={testIdPrefix + "-solved"}
+          id="solved"
+          type="boolean"
+          isInvalid={Boolean(errors.solved)}
+          {...register("solved", {
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.solved?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Button type="submit" data-testid={testIdPrefix + "-submit"}>
+        {buttonLabel}
+      </Button>
+      <Button
+        variant="Secondary"
+        onClick={() => navigate(-1)}
+        data-testid={testIdPrefix + "-cancel"}
+      >
+        Cancel
+      </Button>
+    </Form>
+  );
+}
+
+export default HelpRequestForm;

--- a/frontend/src/main/components/HelpRequests/HelpRequestForm.js
+++ b/frontend/src/main/components/HelpRequests/HelpRequestForm.js
@@ -170,9 +170,7 @@ function HelpRequestForm({
         </Form.Control.Feedback>
       </Form.Group>
 
-      <Button type="submit">
-        {buttonLabel}
-      </Button>
+      <Button type="submit">{buttonLabel}</Button>
       <Button
         variant="Secondary"
         onClick={() => navigate(-1)}

--- a/frontend/src/main/components/HelpRequests/HelpRequestForm.js
+++ b/frontend/src/main/components/HelpRequests/HelpRequestForm.js
@@ -1,4 +1,4 @@
-import { Button, Form } from "react-bootstrap";
+import { Button, Form, Row, Col } from "react-bootstrap";
 import { useForm } from "react-hook-form";
 import { useNavigate } from "react-router-dom";
 
@@ -43,90 +43,102 @@ function HelpRequestForm({
 
   return (
     <Form onSubmit={handleSubmit(submitAction)}>
-      {initialContents && (
-        <Form.Group className="mb-3">
-          <Form.Label htmlFor="id">Id</Form.Label>
-          <Form.Control
-            data-testid={testIdPrefix + "-id"}
-            id="id"
-            type="text"
-            {...register("id")}
-            value={initialContents.id}
-            disabled
-          />
-        </Form.Group>
-      )}
+      <Row>
+        {initialContents && (
+          <Col>
+            <Form.Group className="mb-3">
+              <Form.Label htmlFor="id">Id</Form.Label>
+              <Form.Control
+                data-testid={testIdPrefix + "-id"}
+                id="id"
+                type="text"
+                {...register("id")}
+                value={initialContents.id}
+                disabled
+              />
+            </Form.Group>
+          </Col>
+        )}
 
-      <Form.Group className="mb-3">
-        <Form.Label htmlFor="requesterEmail">Email</Form.Label>
-        <Form.Control
-          data-testid={testIdPrefix + "-requesterEmail"}
-          id="requesterEmail"
-          type="text"
-          isInvalid={Boolean(errors.requesterEmail)}
-          {...register("requesterEmail", {
-            required: "Email is required.",
-            maxLength: {
-              value: 255,
-              message: "Max length 255 characters",
-            },
-          })}
-        />
-        <Form.Control.Feedback type="invalid">
-          {errors.requesterEmail?.message}
-        </Form.Control.Feedback>
-      </Form.Group>
+        <Col>
+          <Form.Group className="mb-3">
+            <Form.Label htmlFor="requesterEmail">Email</Form.Label>
+            <Form.Control
+              data-testid={testIdPrefix + "-requesterEmail"}
+              id="requesterEmail"
+              type="text"
+              isInvalid={Boolean(errors.requesterEmail)}
+              {...register("requesterEmail", {
+                required: "Email is required.",
+                maxLength: {
+                  value: 255,
+                  message: "Max length 255 characters",
+                },
+              })}
+            />
+            <Form.Control.Feedback type="invalid">
+              {errors.requesterEmail?.message}
+            </Form.Control.Feedback>
+          </Form.Group>
+        </Col>
 
-      <Form.Group className="mb-3">
-        <Form.Label htmlFor="teamId">Team ID</Form.Label>
-        <Form.Control
-          data-testid={testIdPrefix + "-teamId"}
-          id="teamId"
-          type="text"
-          isInvalid={Boolean(errors.teamId)}
-          {...register("teamId", {
-            required: "Team ID is required.",
-          })}
-        />
-        <Form.Control.Feedback type="invalid">
-          {errors.teamId?.message}
-        </Form.Control.Feedback>
-      </Form.Group>
-
-      <Form.Group className="mb-3">
-        <Form.Label htmlFor="tableOrBreakoutRoom">
-          Table/Breakout Room #
-        </Form.Label>
-        <Form.Control
-          data-testid={testIdPrefix + "-tableOrBreakoutRoom"}
-          id="tableOrBreakoutRoom"
-          type="text"
-          isInvalid={Boolean(errors.tableOrBreakoutRoom)}
-          {...register("tableOrBreakoutRoom", {
-            required: "Table or Breakout Room number is required.",
-          })}
-        />
-        <Form.Control.Feedback type="invalid">
-          {errors.tableOrBreakoutRoom?.message}
-        </Form.Control.Feedback>
-      </Form.Group>
-
-      <Form.Group className="mb-3">
-        <Form.Label htmlFor="requestTime">Request Time (in UTC)</Form.Label>
-        <Form.Control
-          data-testid={testIdPrefix + "-requestTime"}
-          id="requestTime"
-          type="datetime-local"
-          isInvalid={Boolean(errors.requestTime)}
-          {...register("requestTime", {
-            required: true,
-            pattern: isodate_regex,
-          })}
-        />
-        <Form.Control.Feedback type="invalid">
-          {errors.requestTime && "Request Time is required. "}
-        </Form.Control.Feedback>
-      </Form.Group>
+        <Col>
+          <Form.Group className="mb-3">
+            <Form.Label htmlFor="teamId">Team ID</Form.Label>
+            <Form.Control
+              data-testid={testIdPrefix + "-teamId"}
+              id="teamId"
+              type="text"
+              isInvalid={Boolean(errors.teamId)}
+              {...register("teamId", {
+                required: "Team ID is required.",
+              })}
+            />
+            <Form.Control.Feedback type="invalid">
+              {errors.teamId?.message}
+            </Form.Control.Feedback>
+          </Form.Group>
+        </Col>
+      </Row>
+      <Row>
+        <Col>
+          <Form.Group className="mb-3">
+            <Form.Label htmlFor="tableOrBreakoutRoom">
+              Table/Breakout Room #
+            </Form.Label>
+            <Form.Control
+              data-testid={testIdPrefix + "-tableOrBreakoutRoom"}
+              id="tableOrBreakoutRoom"
+              type="text"
+              isInvalid={Boolean(errors.tableOrBreakoutRoom)}
+              {...register("tableOrBreakoutRoom", {
+                required: "Table or Breakout Room number is required.",
+              })}
+            />
+            <Form.Control.Feedback type="invalid">
+              {errors.tableOrBreakoutRoom?.message}
+            </Form.Control.Feedback>
+          </Form.Group>
+        </Col>
+        <Col>
+          <Form.Group className="mb-3">
+            <Form.Label htmlFor="requestTime">Request Time (in UTC)</Form.Label>
+            <Form.Control
+              data-testid={testIdPrefix + "-requestTime"}
+              id="requestTime"
+              type="datetime-local"
+              isInvalid={Boolean(errors.requestTime)}
+              {...register("requestTime", {
+                required: true,
+                pattern: isodate_regex,
+              })}
+            />
+            <Form.Control.Feedback type="invalid">
+              {errors.requestTime && "Request Time is required. "}
+            </Form.Control.Feedback>
+          </Form.Group>
+        </Col>
+      </Row>
 
       <Form.Group className="mb-3">
         <Form.Label htmlFor="explanation">Explanation</Form.Label>

--- a/frontend/src/main/components/HelpRequests/HelpRequestForm.js
+++ b/frontend/src/main/components/HelpRequests/HelpRequestForm.js
@@ -72,7 +72,7 @@ function HelpRequestForm({
                 required: "Email is required.",
                 maxLength: {
                   value: 255,
-                  message: "Max length 255 characters",
+                  message: "Email - Max length 255 characters",
                 },
               })}
             />
@@ -86,7 +86,6 @@ function HelpRequestForm({
           <Form.Group className="mb-3">
             <Form.Label htmlFor="teamId">Team ID</Form.Label>
             <Form.Control
-              data-testid={testIdPrefix + "-teamId"}
               id="teamId"
               type="text"
               isInvalid={Boolean(errors.teamId)}
@@ -107,7 +106,6 @@ function HelpRequestForm({
               Table/Breakout Room #
             </Form.Label>
             <Form.Control
-              data-testid={testIdPrefix + "-tableOrBreakoutRoom"}
               id="tableOrBreakoutRoom"
               type="text"
               isInvalid={Boolean(errors.tableOrBreakoutRoom)}
@@ -124,7 +122,6 @@ function HelpRequestForm({
           <Form.Group className="mb-3">
             <Form.Label htmlFor="requestTime">Request Time (in UTC)</Form.Label>
             <Form.Control
-              data-testid={testIdPrefix + "-requestTime"}
               id="requestTime"
               type="datetime-local"
               isInvalid={Boolean(errors.requestTime)}
@@ -151,7 +148,7 @@ function HelpRequestForm({
             required: "Explanation is required.",
             maxLength: {
               value: 255,
-              message: "Max length 255 characters",
+              message: "Explanation - Max length 255 characters",
             },
           })}
         />
@@ -163,7 +160,6 @@ function HelpRequestForm({
       <Form.Group className="mb-3">
         <Form.Label htmlFor="solved">Is it Solved? </Form.Label>
         <Form.Control
-          data-testid={testIdPrefix + "-solved"}
           id="solved"
           type="boolean"
           isInvalid={Boolean(errors.solved)}
@@ -174,7 +170,7 @@ function HelpRequestForm({
         </Form.Control.Feedback>
       </Form.Group>
 
-      <Button type="submit" data-testid={testIdPrefix + "-submit"}>
+      <Button type="submit">
         {buttonLabel}
       </Button>
       <Button

--- a/frontend/src/main/components/HelpRequests/HelpRequestTable.js
+++ b/frontend/src/main/components/HelpRequests/HelpRequestTable.js
@@ -1,0 +1,86 @@
+import React from "react";
+import OurTable, { ButtonColumn } from "main/components/OurTable";
+
+import { useBackendMutation } from "main/utils/useBackend";
+import {
+  cellToAxiosParamsDelete,
+  onDeleteSuccess,
+} from "main/utils/helpRequestUtils";
+import { useNavigate } from "react-router-dom";
+import { hasRole } from "main/utils/currentUser";
+
+export default function HelpRequestTable({
+  helpRequests,
+  currentUser,
+  testIdPrefix = "HelpRequestTable",
+}) {
+  const navigate = useNavigate();
+
+  const editCallback = (cell) => {
+    navigate(`/helpRequests/edit/${cell.row.values.id}`);
+  };
+
+  // Stryker disable all : hard to test for query caching
+
+  const deleteMutation = useBackendMutation(
+    cellToAxiosParamsDelete,
+    { onSuccess: onDeleteSuccess },
+    ["/api/helpRequests/all"],
+  );
+  // Stryker restore all
+
+  // Stryker disable next-line all : TODO try to make a good test for this
+  const deleteCallback = async (cell) => {
+    deleteMutation.mutate(cell);
+  };
+
+  const columns = [
+    {
+      Header: "id",
+      accessor: "id", // accessor is the "key" in the data
+    },
+
+    {
+      Header: "Email",
+      accessor: "requesterEmail",
+    },
+    {
+      Header: "Team ID",
+      accessor: "teamId",
+    },
+    {
+      Header: "Table/Breakout Room #",
+      accessor: "tableOrBreakoutRoom",
+    },
+    {
+      Header: "Request Time (in UTC)",
+      accessor: "requestTime",
+      Cell: ({ value }) => {
+        const date = new Date(value);
+        return isNaN(date.getTime())
+          ? value
+          : date.toISOString().replace(".000", "");
+      },
+    },
+    {
+      Header: "Explanation",
+      accessor: "explanation",
+    },
+    {
+      Header: "Has it been solved?",
+      accessor: "solved",
+      Cell: ({ value }) => (value ? "Yes" : "No"),
+    },
+  ];
+
+  if (hasRole(currentUser, "ROLE_ADMIN")) {
+    columns.push(ButtonColumn("Edit", "primary", editCallback, testIdPrefix));
+    columns.push(
+      ButtonColumn("Delete", "danger", deleteCallback, testIdPrefix),
+    );
+  }
+
+  return (
+    <OurTable data={helpRequests} columns={columns} testid={testIdPrefix} />
+  );
+}

--- a/frontend/src/main/utils/helpRequestUtils.js
+++ b/frontend/src/main/utils/helpRequestUtils.js
@@ -1,0 +1,16 @@
+import { toast } from "react-toastify";
+
+export function onDeleteSuccess(message) {
+  console.log(message);
+  toast(message);
+}
+
+export function cellToAxiosParamsDelete(cell) {
+  return {
+    url: "/api/helpRequests",
+    method: "DELETE",
+    params: {
+      id: cell.row.values.id,
+    },
+  };
+}

--- a/frontend/src/stories/components/HelpRequest/HelpRequestForm.stories.js
+++ b/frontend/src/stories/components/HelpRequest/HelpRequestForm.stories.js
@@ -1,0 +1,33 @@
+import React from "react";
+import HelpRequestForm from "main/components/HelpRequests/HelpRequestForm";
+import { helpRequestFixtures } from "fixtures/helpRequestFixtures";
+
+export default {
+  title: "components/HelpRequests/HelpRequestForm",
+  component:HelpRequestForm,
+};
+
+const Template = (args) => {
+  return <HelpRequestForm {...args} />;
+};
+
+export const Create = Template.bind({});
+
+Create.args = {
+  buttonLabel: "Create",
+  submitAction: (data) => {
+    console.log("Submit was clicked with data: ", data);
+    window.alert("Submit was clicked with data: " + JSON.stringify(data));
+  },
+};
+
+export const Update = Template.bind({});
+
+Update.args = {
+  initialContents: helpRequestFixtures.oneHelpRequest,
+  buttonLabel: "Update",
+  submitAction: (data) => {
+    console.log("Submit was clicked with data: ", data);
+    window.alert("Submit was clicked with data: " + JSON.stringify(data));
+  },
+};

--- a/frontend/src/stories/components/HelpRequest/HelpRequestForm.stories.js
+++ b/frontend/src/stories/components/HelpRequest/HelpRequestForm.stories.js
@@ -4,7 +4,7 @@ import { helpRequestFixtures } from "fixtures/helpRequestFixtures";
 
 export default {
   title: "components/HelpRequests/HelpRequestForm",
-  component:HelpRequestForm,
+  component: HelpRequestForm,
 };
 
 const Template = (args) => {

--- a/frontend/src/stories/components/HelpRequest/HelpRequestTable.stories.js
+++ b/frontend/src/stories/components/HelpRequest/HelpRequestTable.stories.js
@@ -1,0 +1,46 @@
+import React from "react";
+import HelpRequestTable from "main/components/HelpRequests/HelpRequestTable";
+
+import { helpRequestFixtures } from "fixtures/helpRequestFixtures";
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+import { http, HttpResponse } from "msw";
+
+export default {
+  title: "components/HelpRequests/HelpRequestTable",
+  component: HelpRequestTable,
+};
+
+const Template = (args) => {
+  return <HelpRequestTable {...args} />;
+};
+
+export const Empty = Template.bind({});
+
+Empty.args = {
+  helpRequests: [],
+  currentUser: currentUserFixtures.userOnly,
+};
+
+export const ThreeItemsOrdinaryUser = Template.bind({});
+
+ThreeItemsOrdinaryUser.args = {
+  helpRequests: helpRequestFixtures.threeHelpRequests,
+  currentUser: currentUserFixtures.userOnly,
+};
+
+export const ThreeItemsAdminUser = Template.bind({});
+ThreeItemsAdminUser.args = {
+  helpRequests: helpRequestFixtures.threeHelpRequests,
+  currentUser: currentUserFixtures.adminUser,
+};
+
+ThreeItemsAdminUser.parameters = {
+  msw: [
+    http.delete("/api/helpRequests", () => {
+      return HttpResponse.json(
+        { message: "Help Request deleted successfully" },
+        { status: 200 },
+      );
+    }),
+  ],
+};

--- a/frontend/src/tests/components/HelpRequest/HelpRequest.test.js
+++ b/frontend/src/tests/components/HelpRequest/HelpRequest.test.js
@@ -1,0 +1,109 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { BrowserRouter as Router } from "react-router-dom";
+
+import HelpRequestForm from "main/components/HelpRequests/HelpRequestForm";
+import { helpRequestFixtures } from "fixtures/helpRequestFixtures";
+
+import { QueryClient, QueryClientProvider } from "react-query";
+
+const mockedNavigate = jest.fn();
+
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: () => mockedNavigate,
+}));
+
+describe("HelpRequestForm tests", () => {
+  const queryClient = new QueryClient();
+
+  const expectedHeaders = ["Email", "Team ID", "Table/Breakout Room #", "Request Time (in UTC)","Explanation","Is it Solved?"];
+  const testId = "HelpRequestForm";
+
+  test("renders correctly with no initialContents", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <HelpRequestForm />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText(/Create/)).toBeInTheDocument();
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+  });
+
+  test("renders correctly when passing in initialContents", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <HelpRequestForm initialContents={helpRequestFixtures.oneHelpRequest} />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText(/Create/)).toBeInTheDocument();
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(await screen.findByTestId(`${testId}-id`)).toBeInTheDocument();
+    expect(screen.getByText(`Id`)).toBeInTheDocument();
+  });
+
+  test("that navigate(-1) is called when Cancel is clicked", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <HelpRequestForm />
+        </Router>
+      </QueryClientProvider>,
+    );
+    expect(await screen.findByTestId(`${testId}-cancel`)).toBeInTheDocument();
+    const cancelButton = screen.getByTestId(`${testId}-cancel`);
+
+    fireEvent.click(cancelButton);
+
+    await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith(-1));
+  });
+
+  test("that the correct validations are performed", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <HelpRequestForm />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText(/Create/)).toBeInTheDocument();
+    const submitButton = screen.getByText(/Create/);
+    fireEvent.click(submitButton);
+
+    await screen.findByText(/Email is required./);
+    expect(screen.getByText(/Team ID is required./)).toBeInTheDocument();
+    expect(screen.getByText(/Table or Breakout Room number is required./)).toBeInTheDocument();
+    expect(screen.getByText(/Request Time is required./)).toBeInTheDocument();
+    expect(screen.getByText(/Explanation is required./)).toBeInTheDocument();
+
+    const requesterEmailInput = screen.getByTestId(`${testId}-requesterEmail`);
+    fireEvent.change(requesterEmailInput, { target: { value: "a".repeat(256) } });
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Max length 255 characters/)).toBeInTheDocument();
+    });
+
+    const explanationInput = screen.getByTestId(`${testId}-explanation`);
+    fireEvent.change(explanationInput, { target: { value: "a".repeat(256) } });
+    fireEvent.click(submitButton);
+    await waitFor(() => {
+        expect(screen.getByText(/Max length 255 characters/)).toBeInTheDocument();
+      });
+  });
+});

--- a/frontend/src/tests/components/HelpRequest/HelpRequest.test.js
+++ b/frontend/src/tests/components/HelpRequest/HelpRequest.test.js
@@ -109,14 +109,17 @@ describe("HelpRequestForm tests", () => {
     fireEvent.click(submitButton);
 
     await waitFor(() => {
-      expect(screen.getByText(/Max length 255 characters/)).toBeInTheDocument();
+      expect(screen.getByText(/Email - Max length 255 characters/)).toBeInTheDocument();
     });
 
     const explanationInput = screen.getByTestId(`${testId}-explanation`);
-    fireEvent.change(explanationInput, { target: { value: "a".repeat(256) } });
+    fireEvent.change(explanationInput, {
+         target: { value: "a".repeat(256)},
+    });
     fireEvent.click(submitButton);
+    
     await waitFor(() => {
-      expect(screen.getByText(/Max length 255 characters/)).toBeInTheDocument();
+      expect(screen.getByText(/Explanation - Max length 255 characters/)).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/tests/components/HelpRequest/HelpRequest.test.js
+++ b/frontend/src/tests/components/HelpRequest/HelpRequest.test.js
@@ -109,17 +109,21 @@ describe("HelpRequestForm tests", () => {
     fireEvent.click(submitButton);
 
     await waitFor(() => {
-      expect(screen.getByText(/Email - Max length 255 characters/)).toBeInTheDocument();
+      expect(
+        screen.getByText(/Email - Max length 255 characters/),
+      ).toBeInTheDocument();
     });
 
     const explanationInput = screen.getByTestId(`${testId}-explanation`);
     fireEvent.change(explanationInput, {
-         target: { value: "a".repeat(256)},
+      target: { value: "a".repeat(256) },
     });
     fireEvent.click(submitButton);
-    
+
     await waitFor(() => {
-      expect(screen.getByText(/Explanation - Max length 255 characters/)).toBeInTheDocument();
+      expect(
+        screen.getByText(/Explanation - Max length 255 characters/),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/tests/components/HelpRequest/HelpRequest.test.js
+++ b/frontend/src/tests/components/HelpRequest/HelpRequest.test.js
@@ -16,7 +16,14 @@ jest.mock("react-router-dom", () => ({
 describe("HelpRequestForm tests", () => {
   const queryClient = new QueryClient();
 
-  const expectedHeaders = ["Email", "Team ID", "Table/Breakout Room #", "Request Time (in UTC)","Explanation","Is it Solved?"];
+  const expectedHeaders = [
+    "Email",
+    "Team ID",
+    "Table/Breakout Room #",
+    "Request Time (in UTC)",
+    "Explanation",
+    "Is it Solved?",
+  ];
   const testId = "HelpRequestForm";
 
   test("renders correctly with no initialContents", async () => {
@@ -40,7 +47,9 @@ describe("HelpRequestForm tests", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <Router>
-          <HelpRequestForm initialContents={helpRequestFixtures.oneHelpRequest} />
+          <HelpRequestForm
+            initialContents={helpRequestFixtures.oneHelpRequest}
+          />
         </Router>
       </QueryClientProvider>,
     );
@@ -87,12 +96,16 @@ describe("HelpRequestForm tests", () => {
 
     await screen.findByText(/Email is required./);
     expect(screen.getByText(/Team ID is required./)).toBeInTheDocument();
-    expect(screen.getByText(/Table or Breakout Room number is required./)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Table or Breakout Room number is required./),
+    ).toBeInTheDocument();
     expect(screen.getByText(/Request Time is required./)).toBeInTheDocument();
     expect(screen.getByText(/Explanation is required./)).toBeInTheDocument();
 
     const requesterEmailInput = screen.getByTestId(`${testId}-requesterEmail`);
-    fireEvent.change(requesterEmailInput, { target: { value: "a".repeat(256) } });
+    fireEvent.change(requesterEmailInput, {
+      target: { value: "a".repeat(256) },
+    });
     fireEvent.click(submitButton);
 
     await waitFor(() => {
@@ -103,7 +116,7 @@ describe("HelpRequestForm tests", () => {
     fireEvent.change(explanationInput, { target: { value: "a".repeat(256) } });
     fireEvent.click(submitButton);
     await waitFor(() => {
-        expect(screen.getByText(/Max length 255 characters/)).toBeInTheDocument();
-      });
+      expect(screen.getByText(/Max length 255 characters/)).toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/tests/components/HelpRequest/HelpRequestTable.test.js
+++ b/frontend/src/tests/components/HelpRequest/HelpRequestTable.test.js
@@ -240,4 +240,54 @@ describe("HelpRequestTable tests", () => {
       await waitFor(() => expect(axiosMock.history.delete.length).toBe(1));
       expect(axiosMock.history.delete[0].params).toEqual({ id: 1 });
     });
+
+    test("Solved Boolean is displayed correctly", () => {
+        // arrange
+        const currentUser = currentUserFixtures.adminUser;
+    
+        // act
+        render(
+            <QueryClientProvider client={queryClient}>
+            <MemoryRouter>
+                <HelpRequestTable
+                helpRequests={helpRequestFixtures.threeHelpRequests}
+                currentUser={currentUser}
+                />
+            </MemoryRouter>
+            </QueryClientProvider>,
+        );
+    
+        // assert
+        expect(
+            screen.getByTestId(`${testId}-cell-row-0-col-solved`),
+        ).toHaveTextContent("No");
+        expect(
+            screen.getByTestId(`${testId}-cell-row-1-col-solved`),
+        ).toHaveTextContent("Yes");
+    });
+
+    test("Request Time is displayed correctly", () => {
+        // arrange
+        const currentUser = currentUserFixtures.adminUser;
+    
+        // act
+        render(
+            <QueryClientProvider client={queryClient}>
+            <MemoryRouter>
+                <HelpRequestTable
+                helpRequests={helpRequestFixtures.threeHelpRequests}
+                currentUser={currentUser}
+                />
+            </MemoryRouter>
+            </QueryClientProvider>,
+        );
+    
+        // assert
+        expect(
+            screen.getByTestId(`${testId}-cell-row-0-col-requestTime`),
+        ).toHaveTextContent("2025-04-30T06:26:00Z");
+        expect(
+            screen.getByTestId(`${testId}-cell-row-1-col-requestTime`),
+        ).toHaveTextContent("2025-04-30T06:26:00Z");
+    });
 });

--- a/frontend/src/tests/components/HelpRequest/HelpRequestTable.test.js
+++ b/frontend/src/tests/components/HelpRequest/HelpRequestTable.test.js
@@ -47,7 +47,7 @@ describe("HelpRequestTable tests", () => {
         <MemoryRouter>
           <HelpRequestTable helpRequests={[]} currentUser={currentUser} />
         </MemoryRouter>
-      </QueryClientProvider>
+      </QueryClientProvider>,
     );
 
     // assert
@@ -58,236 +58,236 @@ describe("HelpRequestTable tests", () => {
 
     expectedFields.forEach((field) => {
       const fieldElement = screen.queryByTestId(
-        `${testId}-cell-row-0-col-${field}`
+        `${testId}-cell-row-0-col-${field}`,
       );
       expect(fieldElement).not.toBeInTheDocument();
     });
   });
 
-    test("Has the expected column headers, content and buttons for admin user", () => {
-      // arrange
-      const currentUser = currentUserFixtures.adminUser;
+  test("Has the expected column headers, content and buttons for admin user", () => {
+    // arrange
+    const currentUser = currentUserFixtures.adminUser;
 
-      // act
-      render(
-        <QueryClientProvider client={queryClient}>
-          <MemoryRouter>
-            <HelpRequestTable
-              helpRequests={helpRequestFixtures.threeHelpRequests}
-              currentUser={currentUser}
-            />
-          </MemoryRouter>
-        </QueryClientProvider>,
-      );
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestTable
+            helpRequests={helpRequestFixtures.threeHelpRequests}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
 
-      // assert
-      expectedHeaders.forEach((headerText) => {
-        const header = screen.getByText(headerText);
-        expect(header).toBeInTheDocument();
-      });
-
-      expectedFields.forEach((field) => {
-        const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
-        expect(header).toBeInTheDocument();
-      });
-
-      expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
-        "1",
-      );
-      expect(
-        screen.getByTestId(`${testId}-cell-row-0-col-requesterEmail`),
-      ).toHaveTextContent("fahimzaman@ucsb.edu");
-
-      expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(
-        "3",
-      );
-      expect(
-        screen.getByTestId(`${testId}-cell-row-1-col-teamId`),
-      ).toHaveTextContent("s25-6pm-4");
-
-      const editButton = screen.getByTestId(
-        `${testId}-cell-row-0-col-Edit-button`,
-      );
-      expect(editButton).toBeInTheDocument();
-      expect(editButton).toHaveClass("btn-primary");
-
-      const deleteButton = screen.getByTestId(
-        `${testId}-cell-row-0-col-Delete-button`,
-      );
-      expect(deleteButton).toBeInTheDocument();
-      expect(deleteButton).toHaveClass("btn-danger");
+    // assert
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
     });
 
-    test("Has the expected column headers, content for ordinary user", () => {
-      // arrange
-      const currentUser = currentUserFixtures.userOnly;
-
-      // act
-      render(
-        <QueryClientProvider client={queryClient}>
-          <MemoryRouter>
-            <HelpRequestTable
-              helpRequests={helpRequestFixtures.threeHelpRequests}
-              currentUser={currentUser}
-            />
-          </MemoryRouter>
-        </QueryClientProvider>,
-      );
-
-      // assert
-      expectedHeaders.forEach((headerText) => {
-        const header = screen.getByText(headerText);
-        expect(header).toBeInTheDocument();
-      });
-
-      expectedFields.forEach((field) => {
-        const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
-        expect(header).toBeInTheDocument();
-      });
-
-      expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
-        "1",
-      );
-      expect(
-        screen.getByTestId(`${testId}-cell-row-0-col-requesterEmail`),
-      ).toHaveTextContent("fahimzaman@ucsb.edu");
-
-      expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(
-        "3",
-      );
-      expect(
-        screen.getByTestId(`${testId}-cell-row-1-col-teamId`),
-      ).toHaveTextContent("s25-6pm-4");
-
-      expect(screen.queryByText("Delete")).not.toBeInTheDocument();
-      expect(screen.queryByText("Edit")).not.toBeInTheDocument();
+    expectedFields.forEach((field) => {
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
     });
 
-    test("Edit button navigates to the edit page", async () => {
-      // arrange
-      const currentUser = currentUserFixtures.adminUser;
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
+      "1",
+    );
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-requesterEmail`),
+    ).toHaveTextContent("fahimzaman@ucsb.edu");
 
-      // act - render the component
-      render(
-        <QueryClientProvider client={queryClient}>
-          <MemoryRouter>
-            <HelpRequestTable
-              helpRequests={helpRequestFixtures.threeHelpRequests}
-              currentUser={currentUser}
-            />
-          </MemoryRouter>
-        </QueryClientProvider>,
-      );
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(
+      "3",
+    );
+    expect(
+      screen.getByTestId(`${testId}-cell-row-1-col-teamId`),
+    ).toHaveTextContent("s25-6pm-4");
 
-      // assert - check that the expected content is rendered
-      expect(
-        await screen.findByTestId(`${testId}-cell-row-0-col-id`),
-      ).toHaveTextContent("1");
+    const editButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Edit-button`,
+    );
+    expect(editButton).toBeInTheDocument();
+    expect(editButton).toHaveClass("btn-primary");
 
-      const editButton = screen.getByTestId(
-        `${testId}-cell-row-0-col-Edit-button`,
-      );
-      expect(editButton).toBeInTheDocument();
+    const deleteButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Delete-button`,
+    );
+    expect(deleteButton).toBeInTheDocument();
+    expect(deleteButton).toHaveClass("btn-danger");
+  });
 
-      // act - click the edit button
-      fireEvent.click(editButton);
+  test("Has the expected column headers, content for ordinary user", () => {
+    // arrange
+    const currentUser = currentUserFixtures.userOnly;
 
-      // assert - check that the navigate function was called with the expected path
-      await waitFor(() =>
-        expect(mockedNavigate).toHaveBeenCalledWith("/helpRequests/edit/1"),
-      );
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestTable
+            helpRequests={helpRequestFixtures.threeHelpRequests}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // assert
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
     });
 
-    test("Delete button calls delete callback", async () => {
-      // arrange
-      const currentUser = currentUserFixtures.adminUser;
-
-      const axiosMock = new AxiosMockAdapter(axios);
-      axiosMock
-        .onDelete("/api/helpRequests")
-        .reply(200, { message: "Help Request deleted" });
-
-      // act - render the component
-      render(
-        <QueryClientProvider client={queryClient}>
-          <MemoryRouter>
-            <HelpRequestTable
-              helpRequests={helpRequestFixtures.threeHelpRequests}
-              currentUser={currentUser}
-            />
-          </MemoryRouter>
-        </QueryClientProvider>,
-      );
-
-      // assert - check that the expected content is rendered
-      expect(
-        await screen.findByTestId(`${testId}-cell-row-0-col-id`),
-      ).toHaveTextContent("1");
-      expect(
-        screen.getByTestId(`${testId}-cell-row-0-col-requesterEmail`),
-      ).toHaveTextContent("fahimzaman@ucsb.edu");
-
-      const deleteButton = screen.getByTestId(
-        `${testId}-cell-row-0-col-Delete-button`,
-      );
-      expect(deleteButton).toBeInTheDocument();
-
-      // act - click the delete button
-      fireEvent.click(deleteButton);
-
-      // assert - check that the delete endpoint was called
-
-      await waitFor(() => expect(axiosMock.history.delete.length).toBe(1));
-      expect(axiosMock.history.delete[0].params).toEqual({ id: 1 });
+    expectedFields.forEach((field) => {
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
     });
 
-    test("Solved Boolean is displayed correctly", () => {
-        // arrange
-        const currentUser = currentUserFixtures.adminUser;
-    
-        // act
-        render(
-            <QueryClientProvider client={queryClient}>
-            <MemoryRouter>
-                <HelpRequestTable
-                helpRequests={helpRequestFixtures.threeHelpRequests}
-                currentUser={currentUser}
-                />
-            </MemoryRouter>
-            </QueryClientProvider>,
-        );
-    
-        // assert
-        expect(
-            screen.getByTestId(`${testId}-cell-row-0-col-solved`),
-        ).toHaveTextContent("No");
-        expect(
-            screen.getByTestId(`${testId}-cell-row-1-col-solved`),
-        ).toHaveTextContent("Yes");
-    });
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
+      "1",
+    );
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-requesterEmail`),
+    ).toHaveTextContent("fahimzaman@ucsb.edu");
 
-    test("Request Time is displayed correctly", () => {
-        // arrange
-        const currentUser = currentUserFixtures.adminUser;
-    
-        // act
-        render(
-            <QueryClientProvider client={queryClient}>
-            <MemoryRouter>
-                <HelpRequestTable
-                helpRequests={helpRequestFixtures.threeHelpRequests}
-                currentUser={currentUser}
-                />
-            </MemoryRouter>
-            </QueryClientProvider>,
-        );
-    
-        // assert
-        expect(
-            screen.getByTestId(`${testId}-cell-row-0-col-requestTime`),
-        ).toHaveTextContent("2025-04-30T06:26:00Z");
-        expect(
-            screen.getByTestId(`${testId}-cell-row-1-col-requestTime`),
-        ).toHaveTextContent("2025-04-30T06:26:00Z");
-    });
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(
+      "3",
+    );
+    expect(
+      screen.getByTestId(`${testId}-cell-row-1-col-teamId`),
+    ).toHaveTextContent("s25-6pm-4");
+
+    expect(screen.queryByText("Delete")).not.toBeInTheDocument();
+    expect(screen.queryByText("Edit")).not.toBeInTheDocument();
+  });
+
+  test("Edit button navigates to the edit page", async () => {
+    // arrange
+    const currentUser = currentUserFixtures.adminUser;
+
+    // act - render the component
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestTable
+            helpRequests={helpRequestFixtures.threeHelpRequests}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // assert - check that the expected content is rendered
+    expect(
+      await screen.findByTestId(`${testId}-cell-row-0-col-id`),
+    ).toHaveTextContent("1");
+
+    const editButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Edit-button`,
+    );
+    expect(editButton).toBeInTheDocument();
+
+    // act - click the edit button
+    fireEvent.click(editButton);
+
+    // assert - check that the navigate function was called with the expected path
+    await waitFor(() =>
+      expect(mockedNavigate).toHaveBeenCalledWith("/helpRequests/edit/1"),
+    );
+  });
+
+  test("Delete button calls delete callback", async () => {
+    // arrange
+    const currentUser = currentUserFixtures.adminUser;
+
+    const axiosMock = new AxiosMockAdapter(axios);
+    axiosMock
+      .onDelete("/api/helpRequests")
+      .reply(200, { message: "Help Request deleted" });
+
+    // act - render the component
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestTable
+            helpRequests={helpRequestFixtures.threeHelpRequests}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // assert - check that the expected content is rendered
+    expect(
+      await screen.findByTestId(`${testId}-cell-row-0-col-id`),
+    ).toHaveTextContent("1");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-requesterEmail`),
+    ).toHaveTextContent("fahimzaman@ucsb.edu");
+
+    const deleteButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Delete-button`,
+    );
+    expect(deleteButton).toBeInTheDocument();
+
+    // act - click the delete button
+    fireEvent.click(deleteButton);
+
+    // assert - check that the delete endpoint was called
+
+    await waitFor(() => expect(axiosMock.history.delete.length).toBe(1));
+    expect(axiosMock.history.delete[0].params).toEqual({ id: 1 });
+  });
+
+  test("Solved Boolean is displayed correctly", () => {
+    // arrange
+    const currentUser = currentUserFixtures.adminUser;
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestTable
+            helpRequests={helpRequestFixtures.threeHelpRequests}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // assert
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-solved`),
+    ).toHaveTextContent("No");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-1-col-solved`),
+    ).toHaveTextContent("Yes");
+  });
+
+  test("Request Time is displayed correctly", () => {
+    // arrange
+    const currentUser = currentUserFixtures.adminUser;
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestTable
+            helpRequests={helpRequestFixtures.threeHelpRequests}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // assert
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-requestTime`),
+    ).toHaveTextContent("2025-04-30T06:26:00Z");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-1-col-requestTime`),
+    ).toHaveTextContent("2025-04-30T06:26:00Z");
+  });
 });

--- a/frontend/src/tests/components/HelpRequest/HelpRequestTable.test.js
+++ b/frontend/src/tests/components/HelpRequest/HelpRequestTable.test.js
@@ -1,0 +1,243 @@
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
+import { helpRequestFixtures } from "fixtures/helpRequestFixtures";
+import HelpRequestTable from "main/components/HelpRequests/HelpRequestTable";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+const mockedNavigate = jest.fn();
+
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: () => mockedNavigate,
+}));
+
+describe("HelpRequestTable tests", () => {
+  const queryClient = new QueryClient();
+
+  const expectedHeaders = [
+    "id",
+    "Email",
+    "Team ID",
+    "Table/Breakout Room #",
+    "Request Time (in UTC)",
+    "Explanation",
+    "Has it been solved?",
+  ];
+  const expectedFields = [
+    "id",
+    "requesterEmail",
+    "teamId",
+    "tableOrBreakoutRoom",
+    "requestTime",
+    "explanation",
+    "solved",
+  ];
+  const testId = "HelpRequestTable";
+
+  test("renders empty table correctly", () => {
+    // arrange
+    const currentUser = currentUserFixtures.adminUser;
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestTable helpRequests={[]} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    // assert
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const fieldElement = screen.queryByTestId(
+        `${testId}-cell-row-0-col-${field}`
+      );
+      expect(fieldElement).not.toBeInTheDocument();
+    });
+  });
+
+    test("Has the expected column headers, content and buttons for admin user", () => {
+      // arrange
+      const currentUser = currentUserFixtures.adminUser;
+
+      // act
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <HelpRequestTable
+              helpRequests={helpRequestFixtures.threeHelpRequests}
+              currentUser={currentUser}
+            />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      // assert
+      expectedHeaders.forEach((headerText) => {
+        const header = screen.getByText(headerText);
+        expect(header).toBeInTheDocument();
+      });
+
+      expectedFields.forEach((field) => {
+        const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+        expect(header).toBeInTheDocument();
+      });
+
+      expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
+        "1",
+      );
+      expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-requesterEmail`),
+      ).toHaveTextContent("fahimzaman@ucsb.edu");
+
+      expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(
+        "3",
+      );
+      expect(
+        screen.getByTestId(`${testId}-cell-row-1-col-teamId`),
+      ).toHaveTextContent("s25-6pm-4");
+
+      const editButton = screen.getByTestId(
+        `${testId}-cell-row-0-col-Edit-button`,
+      );
+      expect(editButton).toBeInTheDocument();
+      expect(editButton).toHaveClass("btn-primary");
+
+      const deleteButton = screen.getByTestId(
+        `${testId}-cell-row-0-col-Delete-button`,
+      );
+      expect(deleteButton).toBeInTheDocument();
+      expect(deleteButton).toHaveClass("btn-danger");
+    });
+
+    test("Has the expected column headers, content for ordinary user", () => {
+      // arrange
+      const currentUser = currentUserFixtures.userOnly;
+
+      // act
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <HelpRequestTable
+              helpRequests={helpRequestFixtures.threeHelpRequests}
+              currentUser={currentUser}
+            />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      // assert
+      expectedHeaders.forEach((headerText) => {
+        const header = screen.getByText(headerText);
+        expect(header).toBeInTheDocument();
+      });
+
+      expectedFields.forEach((field) => {
+        const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+        expect(header).toBeInTheDocument();
+      });
+
+      expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
+        "1",
+      );
+      expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-requesterEmail`),
+      ).toHaveTextContent("fahimzaman@ucsb.edu");
+
+      expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(
+        "3",
+      );
+      expect(
+        screen.getByTestId(`${testId}-cell-row-1-col-teamId`),
+      ).toHaveTextContent("s25-6pm-4");
+
+      expect(screen.queryByText("Delete")).not.toBeInTheDocument();
+      expect(screen.queryByText("Edit")).not.toBeInTheDocument();
+    });
+
+    test("Edit button navigates to the edit page", async () => {
+      // arrange
+      const currentUser = currentUserFixtures.adminUser;
+
+      // act - render the component
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <HelpRequestTable
+              helpRequests={helpRequestFixtures.threeHelpRequests}
+              currentUser={currentUser}
+            />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      // assert - check that the expected content is rendered
+      expect(
+        await screen.findByTestId(`${testId}-cell-row-0-col-id`),
+      ).toHaveTextContent("1");
+
+      const editButton = screen.getByTestId(
+        `${testId}-cell-row-0-col-Edit-button`,
+      );
+      expect(editButton).toBeInTheDocument();
+
+      // act - click the edit button
+      fireEvent.click(editButton);
+
+      // assert - check that the navigate function was called with the expected path
+      await waitFor(() =>
+        expect(mockedNavigate).toHaveBeenCalledWith("/helpRequests/edit/1"),
+      );
+    });
+
+    test("Delete button calls delete callback", async () => {
+      // arrange
+      const currentUser = currentUserFixtures.adminUser;
+
+      const axiosMock = new AxiosMockAdapter(axios);
+      axiosMock
+        .onDelete("/api/helpRequests")
+        .reply(200, { message: "Help Request deleted" });
+
+      // act - render the component
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <HelpRequestTable
+              helpRequests={helpRequestFixtures.threeHelpRequests}
+              currentUser={currentUser}
+            />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      // assert - check that the expected content is rendered
+      expect(
+        await screen.findByTestId(`${testId}-cell-row-0-col-id`),
+      ).toHaveTextContent("1");
+      expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-requesterEmail`),
+      ).toHaveTextContent("fahimzaman@ucsb.edu");
+
+      const deleteButton = screen.getByTestId(
+        `${testId}-cell-row-0-col-Delete-button`,
+      );
+      expect(deleteButton).toBeInTheDocument();
+
+      // act - click the delete button
+      fireEvent.click(deleteButton);
+
+      // assert - check that the delete endpoint was called
+
+      await waitFor(() => expect(axiosMock.history.delete.length).toBe(1));
+      expect(axiosMock.history.delete[0].params).toEqual({ id: 1 });
+    });
+});

--- a/frontend/src/tests/utils/HelpRequestUtils.test.js
+++ b/frontend/src/tests/utils/HelpRequestUtils.test.js
@@ -1,0 +1,51 @@
+import {
+  onDeleteSuccess,
+  cellToAxiosParamsDelete,
+} from "main/utils/helpRequestUtils";
+import mockConsole from "jest-mock-console";
+
+const mockToast = jest.fn();
+jest.mock("react-toastify", () => {
+  const originalModule = jest.requireActual("react-toastify");
+  return {
+    __esModule: true,
+    ...originalModule,
+    toast: (x) => mockToast(x),
+  };
+});
+
+describe("helpRequestUtils", () => {
+  describe("onDeleteSuccess", () => {
+    test("It puts the message on console.log and in a toast", () => {
+      // arrange
+      const restoreConsole = mockConsole();
+
+      // act
+      onDeleteSuccess("abc");
+
+      // assert
+      expect(mockToast).toHaveBeenCalledWith("abc");
+      expect(console.log).toHaveBeenCalled();
+      const message = console.log.mock.calls[0][0];
+      expect(message).toMatch("abc");
+
+      restoreConsole();
+    });
+  });
+  describe("cellToAxiosParamsDelete", () => {
+    test("It returns the correct params", () => {
+      // arrange
+      const cell = { row: { values: { id: 17 } } };
+
+      // act
+      const result = cellToAxiosParamsDelete(cell);
+
+      // assert
+      expect(result).toEqual({
+        url: "/api/helpRequests",
+        method: "DELETE",
+        params: { id: 17 },
+      });
+    });
+  });
+});


### PR DESCRIPTION
Closes #47
implemented code for helpRequest table to display info on the actual frontend of the website.

storybook link: https://680bf70007007d248283b8ef-dtqnlswefx.chromatic.com/?path=/story/components-helprequests-helprequesttable--empty

# Table Empty
<img width="985" alt="Screenshot 2025-05-02 at 8 53 36 PM" src="https://github.com/user-attachments/assets/57fc8ce0-0f8c-4bb8-8e84-f49c554c2bfe" />

# Table User
<img width="811" alt="Screenshot 2025-05-02 at 8 54 09 PM" src="https://github.com/user-attachments/assets/6e0295cc-bef8-42b7-8a1e-c607430193d1" />

# Table Admir
<img width="923" alt="Screenshot 2025-05-02 at 8 54 45 PM" src="https://github.com/user-attachments/assets/c9fbf4c8-6808-408f-a9df-f7424252eebc" />

